### PR TITLE
Avoid using deprecated Buffer constructor

### DIFF
--- a/lib/deceiver.js
+++ b/lib/deceiver.js
@@ -241,7 +241,7 @@ Deceiver.prototype.emitBody = function emitBody (buffer) {
 
 Deceiver.prototype._emitEmpty = function _emitEmpty () {
   // Emit data to force out handling of UPGRADE
-  var empty = new Buffer(0)
+  var empty = Buffer.concat([])
   if (this.socket.ondata) { this.socket.ondata(empty, 0, 0) } else {
     this.socket.emit('data', empty)
   }


### PR DESCRIPTION
`Buffer.concat([])` returns an empty buffer all the way down to 0.8.x.

Alternative way would be to just use `Buffer.alloc(0)` and drop support for outdated Node.js versions.

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

Tracking: https://github.com/nodejs/node/issues/19079