### PR TITLE
Avoid using deprecated process.binding('http_parser')

### DIFF
--- a/lib/deceiver.js
+++ b/lib/deceiver.js
@@ -21,12 +21,18 @@ var kOnHeadersComplete
 var kOnMessageComplete
 var kOnBody
 if (mode === 'normal' || mode === 'modern') {
-  HTTPParser = process.binding('http_parser').HTTPParser
-  methods = HTTPParser.methods
+  HTTPParser = require('_http_common').HTTPParser
+  methods = require('_http_common').methods
 
-  // v6
-  if (!methods) {
+  // <= v11
+  if (!HTTPParser) {
+    HTTPParser = process.binding('http_parser').HTTPParser
     methods = process.binding('http_parser').methods
+  }
+
+  // <= v5
+  if (!methods) {
+    methods = HTTPParser.methods
   }
 
   reverseMethods = {}


### PR DESCRIPTION
Closes https://github.com/spdy-http2/http-deceiver/issues/6
Refs: https://nodejs.org/api/deprecations.html#DEP0111